### PR TITLE
Déplacer et simplifier les garanties

### DIFF
--- a/VBACCI
+++ b/VBACCI
@@ -347,6 +347,8 @@ Sub ResumerCCI()
         .PivotFields("Garant").Orientation = xlColumnField
         On Error GoTo 0
         .AddDataField .PivotFields("ID"), "Nb sociétés", xlCount
+        ' Afficher le nombre de garants en zone Valeurs (utiliser Max pour éviter les doublons)
+        .AddDataField .PivotFields("Nb garants (dirigeant)"), "Nb garants", xlMax
         .RowGrand = True
         .ColumnGrand = True
         .ShowTableStyleRowStripes = True
@@ -643,39 +645,7 @@ Sub ResumerCCI()
 
     wsComp.Columns.AutoFit
 
-    ' ==============================
-    ' Filtrer le TCD pour ne garder que les dirigeants avec plusieurs garants
-    ' ==============================
-    Dim allowedDir As Object
-    Set allowedDir = CreateObject("Scripting.Dictionary")
-    For Each key In dictDirGarantFreq.Keys
-        If dictDirGarantFreq(key).Count > 1 Then
-            If dirKeyToDisplay.Exists(key) Then
-                If Not allowedDir.Exists(dirKeyToDisplay(key)) Then allowedDir.Add dirKeyToDisplay(key), True
-            End If
-        End If
-    Next key
-
-    ' Remplacer la boucle de visibilité par un filtre de valeur quand possible
-    On Error Resume Next
-    Set wsPivot = wbTarget.Sheets("PivotDirigeantGarant")
-    If Not wsPivot Is Nothing Then
-        Set pt = wsPivot.PivotTables("TCD_DirGar")
-        If Not pt Is Nothing Then
-            pt.ManualUpdate = True
-            Dim valField As PivotField
-            ' Ajouter le champ "Nb garants (dirigeant)" comme champ de données temporaire si nécessaire
-            If pt.PivotFields("Nb garants (dirigeant)").Orientation = xlHidden Then
-                pt.PivotFields("Nb garants (dirigeant)").Orientation = xlRowField ' temporaire pour permettre le filtrage de valeur
-                pt.PivotFields("Nb garants (dirigeant)").Position = 2
-            End If
-            ' Appliquer un filtre en amont via AutoFilter sur la source pour éviter le scan des PivotItems
-            ' (si le champ n'existe pas dans le TCD, on ne fait rien)
-            pt.ManualUpdate = False
-            pt.RefreshTable
-        End If
-    End If
-    On Error GoTo 0
+    ' Champ "Nb garants (dirigeant)" désormais en zone Valeurs — aucun hack de ligne nécessaire
 
     ' ==============================
     ' Feuille de trace pour audit (IDs, dirigeants et principaux)


### PR DESCRIPTION
Move 'Nb garants' to pivot table Values and simplify associated code.

The field 'Nb garants (dirigeant)' was previously added as a temporary row field to enable filtering. By moving it directly to the Values area as 'Nb garants' with `xlMax`, this temporary row field hack and its associated filtering logic are no longer necessary, leading to significant code simplification.

---
<a href="https://cursor.com/background-agent?bcId=bc-20a71d15-41a3-4334-8812-6e7c05ed9411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20a71d15-41a3-4334-8812-6e7c05ed9411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

